### PR TITLE
Make "opc diff" send exit status of 0/1

### DIFF
--- a/opcdiag/cli.py
+++ b/opcdiag/cli.py
@@ -50,7 +50,7 @@ class CommandController(object):
         args = self._parser.parse_args(argv)
         command = args.command
         command.validate(args)
-        command.execute(args, self._app_controller)
+        return command.execute(args, self._app_controller)
 
 
 class Command(object):
@@ -145,7 +145,7 @@ class DiffCommand(Command):
         return parser
 
     def execute(self, args, app_controller):
-        app_controller.diff_pkg(args.pkg_1_path, args.pkg_2_path)
+        return app_controller.diff_pkg(args.pkg_1_path, args.pkg_2_path)
 
     def validate(self, args):
         paths_that_should_exist = (
@@ -301,4 +301,4 @@ class SubstituteCommand(Command):
 
 def main(argv=None):
     command_controller = CommandController.new()
-    command_controller.execute(argv)
+    return command_controller.execute(argv)

--- a/opcdiag/controller.py
+++ b/opcdiag/controller.py
@@ -57,6 +57,9 @@ class OpcController(object):
         xml_part_diffs = DiffPresenter.xml_part_diffs(package_1, package_2)
         OpcView.package_diff(content_types_diff, rels_diffs, xml_part_diffs)
 
+        if content_types_diff or rels_diffs or xml_part_diffs:
+            return 1
+
     def extract_package(self, package_path, extract_dirpath):
         """
         Extract the contents of the package at *package_path* to individual


### PR DESCRIPTION
This makes `opc diff` behave like `diff`. This is useful when using the command in scripts.
