### PR TITLE
Print diff correctly in Python 3

### DIFF
--- a/opcdiag/view.py
+++ b/opcdiag/view.py
@@ -20,8 +20,9 @@ def _write(text):
     """
     Write *text* to stdout
     """
-    bytes_out = text.encode('utf-8')
-    print(bytes_out, end='', file=sys.stdout)
+    if sys.version_info[0] == 2:
+        text = text.encode('utf-8')
+    print(text, end='', file=sys.stdout)
 
 
 class OpcView(object):


### PR DESCRIPTION
Previously, it would print stuff like the following.

```
b'--- /tmp/1/[Content_Types].xml\n\n+++ /tmp/2/[Content_Types].xml\n\n@@ -1,9 +1,9 @@\n\n <?xml version=\'1.0\' encoding=\'UTF-8\' standalone=\'yes\'?>\n <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">\n-  <Default ContentType="application/vnd.openxmlformats-officedocument.presentationml.printerSettings" Extension="bin"/>\n-  <Default ContentType="application/vnd.openxmlformats-package.relationships+xml" Extension="rels"/>\n-  <Default ContentType="application/xml" Extension="xml"/>\n-  <Default ContentType="image/jpeg" Extension="jpeg"/>\n+  <Default Extension="bin" ContentType="application/vnd.openxmlformats-officedocument.presentationml.printerSettings"/>\n+  <Default Extension="jpeg" ContentType="image/jpeg"/>\n+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>\n+  <Default Extension="xml" ContentType="application/xml"/>\n   <Override PartName="/docProps/app.xml" ContentType="application/vnd.openxmlformats-officedocument.extended-properties+xml"/>\n   <Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>\n   <Override PartName="/ppt/presProps.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presProps+xml"/>\n\n--- /tmp/1/ppt/presentation.xml\n\n+++ /tmp/2/ppt/presentation.xml\n\n@@ -10,8 +10,8 @@\n\n     <p:sldMasterId id="2147483648" r:id="rId1"/>\n   </p:sldMasterIdLst>\n   <p:sldIdLst>\n-    <p:sldId id="256" r:id="rId7"/>\n-    <p:sldId id="257" r:id="rId8"/>\n+    <p:sldId r:id="rId7" id="256"/>\n+    <p:sldId r:id="rId8" id="257"/>\n   </p:sldIdLst>\n   <p:sldSz cx="9144000" cy="6858000" type="screen4x3"/>\n   <p:notesSz cx="6858000" cy="9144000"/>\n'
```
