### PR TITLE
rename itervalues -> values as itervalues is removed in python3

### DIFF
--- a/opcdiag/model.py
+++ b/opcdiag/model.py
@@ -51,7 +51,7 @@ class Package(object):
         human-readable format. If viewed after this method is called, the XML
         appears "pretty printed".
         """
-        for pkg_item in self._pkg_items.itervalues():
+        for pkg_item in self._pkg_items.values():
             pkg_item.prettify_xml()
 
     @property


### PR DESCRIPTION
Hi @scanny 

I encountered "Dict object has no attribute itervalues" when using `opc extract command` hence, renaming itervalues -> values as itervalues was being removed in python 3 and python 2 is no longer alive.