### PR TITLE
fix(build): remove self-dependency

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 History
 =======
 
+1.1.1 (2024-10-10)
+------------------
+
+* Remove self-dependency from `pyproject.toml`.
+
 1.1.0 (2024-09-22)
 ------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opc-diag"
-version = "1.1.0"
+version = "1.1.1"
 authors = [{name = "Steve Canny", email = "stcanny@gmail.com"}]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -21,10 +21,7 @@ classifiers = [
     "Topic :: Office/Business :: Office Suites",
     "Topic :: Software Development :: Libraries",
 ]
-dependencies = [
-    "lxml>=4",
-    "opc-diag",
-]
+dependencies = ["lxml>=4"]
 description = "A command-line application for exploring Microsoft Word, Excel, and PowerPoint files from Office 2007 and later."
 keywords = ["docx", "pptx", "xlsx", "office", "openxml", "word", "powerpoint", "excel"]
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -631,7 +631,7 @@ wheels = [
 
 [[package]]
 name = "opc-diag"
-version = "1.0.1"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "lxml" },
@@ -654,10 +654,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "lxml", specifier = ">=4" },
-    { name = "opc-diag", editable = "." },
-]
+requires-dist = [{ name = "lxml", specifier = ">=4" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Not sure how it got there but `opc-diag` should not depend upon itself.

Remove `opc-diag` as dependency from `pyproject.toml`.